### PR TITLE
EnemyDrop

### DIFF
--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -1,12 +1,22 @@
 ﻿using UnityEngine;
 using System.Collections;
 
+public enum PowerUps
+{
+    Clone,
+    Rapid,
+    Multi,
+    None
+}
+
 public abstract class Enemy : MonoBehaviour {
+    private const float PERCENTAGE_DROP = 20f; //Ten percent of enemies drop items
     protected bool _alive = false;
     protected Lane _currentLane;
     protected int _score = 0;
     protected bool _invulnerable = false;
-
+    protected PowerUps _powerUp = PowerUps.None;
+    
     public bool Alive {
         get {
             return _alive;
@@ -28,7 +38,7 @@ public abstract class Enemy : MonoBehaviour {
     }
 
     void Start () {
-        
+
     }
 
     void Update () {
@@ -56,6 +66,7 @@ public abstract class Enemy : MonoBehaviour {
             return;
         }
         if(collision.gameObject.tag == "PlayerProjectile") {
+            dropPowerup();
             PlayerProjectile p = collision.gameObject.GetComponent<PlayerProjectile>();
             _alive = false;
             EnemyManager.Instance.removeEnemy(this);
@@ -63,5 +74,60 @@ public abstract class Enemy : MonoBehaviour {
             Destroy(gameObject);
             Score.CurrentScore += _score;
         }
+    }
+
+    protected void dropPowerup()
+    {
+        GUIStyle tempStyle = GUIManager.Instance.defaultStyle;
+        switch (_powerUp)
+        {
+            case PowerUps.Clone:
+                if (GameManager.Instance.CurrentPlayerShips[0].isCloneActivated == false)
+                {
+                    tempStyle.alignment = TextAnchor.MiddleCenter;
+                    GUIManager.Instance.addGUIItem(new GUIItem(Screen.width / 2, ScreenUtil.getPixels(200), "Clone!", tempStyle, 2));
+                }
+                GameManager.Instance.CurrentPlayerShips[0].ActivateClone();
+                break;
+
+            case PowerUps.Multi:
+                GameManager.Instance.CurrentPlayerShips[0].ActivateMulti();
+                tempStyle.alignment = TextAnchor.MiddleCenter;
+                GUIManager.Instance.addGUIItem(new GUIItem(Screen.width / 2, ScreenUtil.getPixels(200), "Multi-Shot!", tempStyle, 2));
+                break;
+
+            case PowerUps.Rapid:
+                GameManager.Instance.CurrentPlayerShips[0].ActivateRapid();
+                tempStyle.alignment = TextAnchor.MiddleCenter;
+                GUIManager.Instance.addGUIItem(new GUIItem(Screen.width / 2, ScreenUtil.getPixels(200), "Rapid Shot!", tempStyle, 2));
+                break;
+        }
+    }
+    void randomPower()
+    {
+        float powerNumber = Random.Range(0f, 3f);
+        if (powerNumber > 2f)
+        {
+            _powerUp = PowerUps.Clone;
+        }
+        else if (powerNumber > 1f)
+        {
+            _powerUp = PowerUps.Multi;
+        }
+        else
+        {
+            _powerUp = PowerUps.Rapid;
+        }
+    }
+
+    protected void randomEnemyDrop()
+    {
+        
+        float temp = Random.Range(0f, 100f);
+        if (temp < PERCENTAGE_DROP)
+        {
+            randomPower();
+        }
+
     }
 }

--- a/Assets/Scripts/Enemy/Pawn.cs
+++ b/Assets/Scripts/Enemy/Pawn.cs
@@ -9,6 +9,7 @@ public class Pawn : Enemy {
 
     void Start () {
         _score = 100;
+        randomEnemyDrop();
     }
 	
     void Update () {

--- a/Assets/Scripts/Enemy/Swirlie.cs
+++ b/Assets/Scripts/Enemy/Swirlie.cs
@@ -30,6 +30,7 @@ public class Swirlie : Enemy {
     {
         _score = 100;
         newPosition = transform.position;
+        randomEnemyDrop();
     }
 
     void Update() {


### PR DESCRIPTION
Enemy Drop:
     - I set it so 20% of the enemies will spawn with a power up attached (although player cant tell yet)
     - Randomly selects the enemies that carries power ups
     - Randomly picks which power up out of the three
     - GUI will tell the player whenever a power up is picked up
           - It will tell the player whenever the Multi-shot and Rapid shot power ups are picked up, even if they are already on (so the player knows that timer is reset)
           - Since it does not matter if clone is picked up when clone is already active, it will not display anything unless clone is currently inactive. 
      - Tested and it looks like it works okay.
     Note: I did not call randomEnemyDrop() in the Enemy class because enemy projectiles and spikes are also enemies. So I called it in the start method of Pawn and Swirlie. So when Crosshatch and Confetti is done, I also have to call it there too. 
